### PR TITLE
Added colorWithFullHex method and made colorWithHex deprecated.

### DIFF
--- a/AVHexColor.h
+++ b/AVHexColor.h
@@ -44,15 +44,9 @@
 /*
  * Convert hexadecimal value to RGB
  *
- * Accepts several hex length:
- * 		1 = 0xB
- * 		2 = 0xGB
- *		3 = 0xRGB
- *		4 = 0xaRGB
- *		6 = 0xRRGGBB
- *		8 = 0xaaRRGGBB
+ * Accepts several hex in full format: 0xaaRRGGBB
  */
-+ (AVColor *)colorWithHex:(UInt32)hexadecimal;
++ (AVColor *)colorWithFullHex:(UInt32)hexadecimal;
 
 /*
  * Convert string hex value to RGB
@@ -64,6 +58,19 @@
  *		8 = #aaRRGGBB
  */
 + (AVColor *)colorWithHexString:(NSString *)hexadecimal;
+
+/*
+ * Convert hexadecimal value to RGB
+ *
+ * Accepts several hex length:
+ * 		1 = 0xB
+ * 		2 = 0xGB
+ *		3 = 0xRGB
+ *		4 = 0xaRGB
+ *		6 = 0xRRGGBB
+ *		8 = 0xaaRRGGBB
+ */
++ (AVColor *)colorWithHex:(UInt32)hexadecimal __attribute__((deprecated("Use 'colorWithFullHex:' instead")));
 
 /*
  * Convert hexadecimal value to RGB

--- a/AVHexColor.m
+++ b/AVHexColor.m
@@ -35,11 +35,37 @@
 @implementation AVHexColor
 
 #pragma mark - Category Methods
++ (AVColor *)colorWithFullHex:(UInt32)hexadecimal
+{
+    CGFloat red, green, blue, alpha = 1.0f;
+    NSString *hexString = [NSString stringWithFormat: @"%X" , (unsigned int)hexadecimal];
+
+    if ( hexString.length == 8 )
+    {
+        // bitwise AND operation
+        // hexadecimal's first 2 values
+        alpha = (CGFloat)(( hexadecimal >> 24 ) & 0xFF ) / 255.0f;
+        // hexadecimal's third and fourth values
+        red = (CGFloat)(( hexadecimal >> 16 ) & 0xFF ) / 255.0f;
+        // hexadecimal's fifth and sixth values
+        green = (CGFloat)(( hexadecimal >> 8 ) & 0xFF ) / 255.0f;
+        // hexadecimal's seventh and eighth
+        blue = (CGFloat)( hexadecimal & 0xFF ) / 255.0f;
+    }
+    else
+    {
+        return nil;
+    }
+
+    AVColor *color = [AVColor colorWithRed:red green:green blue:blue alpha:alpha];
+    return color;
+}
+
 + (AVColor *)colorWithHex:(UInt32)hexadecimal
 {
 	CGFloat red, green, blue, alpha = 1.0f;
 	NSString *hexString = [NSString stringWithFormat: @"%03X" , (unsigned int)hexadecimal];
-	
+
 	if ( hexString.length == 3 )
 	{
 		// bitwise AND operation
@@ -88,7 +114,7 @@
 	{
 		return nil;
 	}
-	
+
 	AVColor *color = [AVColor colorWithRed:red green:green blue:blue alpha:alpha];
 	return color;
 }


### PR DESCRIPTION
Unfortunately `colorWithHex` returns bad colours for hexes beginning with zeros.

Example:
`UIColor *color1 = [AVHexColor colorWithHexString:@"#00545b"];` 
`//color1 == "UIDeviceRGBColorSpace 0 0.329412 0.356863 1"`

`UIColor *color2 = [AVHexColor colorWithHex:0x00545b];`
`//color2 == "UIDeviceRGBColorSpace 0.266667 0.333333 0.733333 0.333333"`

Reason:
There is now way to tell how many leading zeros we should pass to string in this step:
`NSString *hexString = [NSString stringWithFormat: @"%03X" , (unsigned int)hexadecimal];`

Solution:
I've made `colorWithHex` deprecated and created new method that needs full hex: `colorWithFullHex`.

Cheers!
